### PR TITLE
Restore eventbrowser_st_id

### DIFF
--- a/cgi-bin/eventbrowser_st_id
+++ b/cgi-bin/eventbrowser_st_id
@@ -1,0 +1,44 @@
+#!/usr/local/bin/perl -w 
+use strict;
+use lib "../cgi-modules";
+use GKB::StableIdentifierDatabase;
+use CGI qw(:standard);
+use CGI::Carp 'fatalsToBrowser';
+use GKB::FrontPage3;
+
+my $stable = GKB::StableIdentifierDatabase->new();
+#my $browser = '/cgi-bin/instancebrowser?ID=';
+my $browser = '/content/detail/';
+
+my $CGI = CGI->new();
+
+my $st_id = $CGI->param('ST_ID') || $CGI->param('STID') || handle_error('NO STABLE ID TO SEARCH');
+$st_id =~ s/\.\d+$//;
+
+my $db_id = $stable->db_id_from_stable_id($st_id);
+
+# We have an ID, send to instance browser
+if ($db_id) {
+    my $url = "$browser$db_id";
+    print $CGI->redirect($url);
+}
+else {
+    handle_error("Unable to find a Reactome Instance for stable identifier $st_id");
+}
+
+exit 0;
+
+sub handle_error {
+    my ($error_message) = @_;
+
+    my $front_page = GKB::FrontPage3->new("eventbrowser", "/stylesheet.css");
+    my $header = $front_page->get_header();
+    my $footer = $front_page->get_footer();
+
+    print header, $header;
+    print qq(<h1 CLASS="frontpage"><FONT COLOR="RED">Internal error</FONT></h1>\n);
+    print qq(<h1><PRE>\n\n\n$error_message\n\n</PRE></h1>\n);
+    print $footer;
+
+    exit;
+}


### PR DESCRIPTION
It turns out this script should not have been deprecated. There are external resources that have links to it, of the form: https://reactome.org/cgi-bin/eventbrowser_st_id?ST_ID=REACT_169122.1
Without this script, the website simply returns a "404" error.
The original source for this script can be found here: https://github.com/reactome/Release/blob/f3f8eec54e4cb37d77010ff14866a4c11d7b62fe/website/cgi-bin/eventbrowser_st_id